### PR TITLE
Fix/Sort public groups alphabetically

### DIFF
--- a/ckanext/querytool/templates/querytool/public/base_main.html
+++ b/ckanext/querytool/templates/querytool/public/base_main.html
@@ -44,7 +44,7 @@
     <div class="box-items">
       <div class="row">
       {% set groups = h.querytool_get_groups() %}
-      {% for key, value in groups.iteritems() %}
+      {% for key, value in groups|dictsort(false, 'key') %}
       {% set url = h.url_for('querytool_public_list_by_group', group=key) %}
           <div class="span4">
             <a class="query-tool box" href="{{ url }}">

--- a/ckanext/querytool/templates/querytool/public/list.html
+++ b/ckanext/querytool/templates/querytool/public/list.html
@@ -16,7 +16,7 @@
 {% block tools %}
 <div class="container">
    {% if data %}
-     {% for querytool in data | sort %}
+     {% for querytool in data | sort(attribute='title') %}
        {% if not querytool.private %}
         {% snippet 'querytool/public/snippets/query_tool_list_item.html', querytool=querytool %}
        {% endif %}

--- a/ckanext/querytool/templates/querytool/public/list.html
+++ b/ckanext/querytool/templates/querytool/public/list.html
@@ -16,7 +16,7 @@
 {% block tools %}
 <div class="container">
    {% if data %}
-     {% for querytool in data %}
+     {% for querytool in data | sort %}
        {% if not querytool.private %}
         {% snippet 'querytool/public/snippets/query_tool_list_item.html', querytool=querytool %}
        {% endif %}


### PR DESCRIPTION
Fixes: https://gitlab.com/datopian/core/support/-/issues/200
Use sort and dictsort functions of jinja to sort the public groups alphabetically
## Before Fix
![Screenshot from 2020-03-25 18-53-55](https://user-images.githubusercontent.com/57398621/77546135-3f71e000-6ecd-11ea-8e70-e78078f9a1b9.png)
## After Fix
![Screenshot from 2020-03-25 19-12-23](https://user-images.githubusercontent.com/57398621/77546162-47ca1b00-6ecd-11ea-94c2-da79944173ee.png)
![Screenshot from 2020-03-25 20-05-34](https://user-images.githubusercontent.com/57398621/77551363-156fec00-6ed4-11ea-94cf-f829d5619cf0.png)
