### PR TITLE
Feature/add custom title description

### DIFF
--- a/ckanext/querytool/plugin.py
+++ b/ckanext/querytool/plugin.py
@@ -155,7 +155,7 @@ class QuerytoolPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     controller=querytool_controller,
                     action='edit_visualizations')
 
-        map.connect('querytool_public', '/querytool/public/groups',
+        map.connect('querytool_public', '/',
                     controller=querytool_controller, action='querytool_public')
 
         map.connect('querytool_public_reports', '/querytool/public/reports',
@@ -283,3 +283,13 @@ class QuerytoolPlugin(plugins.SingletonPlugin, DefaultTranslation):
         auth_functions = h._get_functions(module_root)
 
         return auth_functions
+
+    # IConfigurer
+
+    def update_config_schema(self, schema):
+        schema.update({
+            'ckan.welcome_page_title': [ignore_missing, unicode],
+            'ckan.welcome_page_description': [ignore_missing, unicode],
+        })
+
+        return schema

--- a/ckanext/querytool/plugin.py
+++ b/ckanext/querytool/plugin.py
@@ -155,7 +155,7 @@ class QuerytoolPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     controller=querytool_controller,
                     action='edit_visualizations')
 
-        map.connect('querytool_public', '/',
+        map.connect('querytool_public', '/querytool/public/groups',
                     controller=querytool_controller, action='querytool_public')
 
         map.connect('querytool_public_reports', '/querytool/public/reports',

--- a/ckanext/querytool/templates/admin/config.html
+++ b/ckanext/querytool/templates/admin/config.html
@@ -1,0 +1,24 @@
+
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block admin_form %}
+
+ {{ super() }}
+
+ {{ form.input('ckan.welcome_page_title', id='field-ckan.welcome_page_title', placeholder=g.welcome_page_title or _('Welcom Page Title'), label=_('Welcome Page Title'), value=data['ckan.welcome_page_title'], error=errors['ckan.welcome_page_title']) }}
+ {{ form.markdown('ckan.welcome_page_description', id='field-ckan.welcome_page_description', placeholder=g.welcome_page_description or _('Welcome Page Description'), label=_('Welcome Page Description'), value=data['ckan.welcome_page_description'], error=errors['ckan.welcome_page_description']) }}
+
+{% endblock %}
+
+
+{% block admin_form_help %}
+
+ {{ super() }}
+
+ <p><strong>Welcome Page Title:</strong> The title presented to users on the home page.</p>
+
+ <p><strong>Welcome Page Description:</strong> The description presented to users on the home page.</p>
+
+{% endblock %}

--- a/ckanext/querytool/templates/querytool/public/base_main.html
+++ b/ckanext/querytool/templates/querytool/public/base_main.html
@@ -30,9 +30,13 @@
           <div class="page-header">
             {% block page_header_inner_content %}
               {% block page_header_icon %}{% endblock %}
-              {% block page_header_title %}<h1>{{ _('Welcome') }}</h1>{% endblock %}
+              {% block page_header_title %}
+                <h1>{{ g.welcome_page_title or _('Welcome') }}</h1>
+              {% endblock %}
               <div class="long-desc">
-                {% block page_header_description %}<p class="page-desc desc">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vulputate sapien augue, ut feugiat eros pulvinar elementum. Nulla sed ante non mi fringilla molestie in et lorem.  </p>{% endblock %}
+                {% block page_header_description %}
+                  <p class="page-desc desc">{{ h.render_markdown(g.welcome_page_description or _('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse vulputate sapien augue, ut feugiat eros pulvinar elementum. Nulla sed ante non mi fringilla molestie in et lorem.')) }}</p>
+                {% endblock %}
               </div>
             {% endblock %}
           </div>


### PR DESCRIPTION
… admin page

closes https://gitlab.com/datopian/vital-strategies-ui/-/issues/59

Are these field names and descriptions fine? Let me know. It's all working for me locally as far as saving and showing up in the text boxes.

![welcome-title-description-1](https://user-images.githubusercontent.com/19521691/98998403-15286d80-2504-11eb-9249-7d1710e6d3dd.png)

![welcome-title-description-2](https://user-images.githubusercontent.com/19521691/98998409-18235e00-2504-11eb-9365-9d03ff5bdf1a.png)
