### PR TITLE
Change CKAN group override function names

### DIFF
--- a/ckanext/querytool/logic/action/create.py
+++ b/ckanext/querytool/logic/action/create.py
@@ -21,7 +21,7 @@ NotFound = logic.NotFound
 log = log.getLogger(__name__)
 
 
-def _group_or_org_create(context, data_dict, is_org=False):
+def _querytool_group_or_org_create(context, data_dict, is_org=False):
     model = context['model']
     user = context['user']
     session = context['session']
@@ -50,7 +50,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
 
     data, errors = lib_plugins.plugin_validate(
         group_plugin, context, data_dict, schema,
-        'organization_create' if is_org else 'group_create')
+        'organization_create' if is_org else 'querytool_group_create')
     log.debug('group_create validate_errs=%r user=%s group=%s data_dict=%r',
               errors, context.get('user'), data_dict.get('name'), data_dict)
 
@@ -169,7 +169,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     return output
 
 
-def group_create(context, data_dict):
+def querytool_group_create(context, data_dict):
     '''Create a new group.
     You must be authorized to create groups.
     Plugins may change the parameters of this function depending on the value
@@ -232,4 +232,4 @@ def group_create(context, data_dict):
         # FIXME better exception?
         raise Exception(_('Trying to create an organization as a group'))
     _check_access('group_create', context, data_dict)
-    return _group_or_org_create(context, data_dict)
+    return _querytool_group_or_org_create(context, data_dict)

--- a/ckanext/querytool/logic/action/delete.py
+++ b/ckanext/querytool/logic/action/delete.py
@@ -36,7 +36,7 @@ def querytool_delete(context, data_dict):
     CkanextQueryTool.delete(id=data_dict['name'])
 
 
-def _group_or_org_delete(context, data_dict, is_org=False):
+def _querytool_group_or_org_delete(context, data_dict, is_org=False):
     '''Delete a group.
     You must be authorized to delete the group.
     :param id: the name or id of the group
@@ -115,10 +115,10 @@ def _group_or_org_delete(context, data_dict, is_org=False):
     model.repo.commit()
 
 
-def group_delete(context, data_dict):
+def querytool_group_delete(context, data_dict):
     '''Delete a group.
     You must be authorized to delete the group.
     :param id: the name or id of the group
     :type id: string
     '''
-    return _group_or_org_delete(context, data_dict)
+    return _querytool_group_or_org_delete(context, data_dict)

--- a/ckanext/querytool/logic/action/update.py
+++ b/ckanext/querytool/logic/action/update.py
@@ -316,7 +316,7 @@ def config_option_update(context, data_dict):
     return data
 
 
-def _group_or_org_update(context, data_dict, is_org=False):
+def _querytool_group_or_org_update(context, data_dict, is_org=False):
     model = context['model']
     user = context['user']
     session = context['session']
@@ -513,7 +513,7 @@ def _group_or_org_update(context, data_dict, is_org=False):
     return model_dictize.group_dictize(group, context)
 
 
-def group_update(context, data_dict):
+def querytool_group_update(context, data_dict):
     '''Update a group.
 
     You must be authorized to edit the group.
@@ -535,6 +535,6 @@ def group_update(context, data_dict):
     # Callers that set context['allow_partial_update'] = True can choose to not
     # specify particular keys and they will be left at their existing
     # values. This includes: packages, users, groups, tags, extras
-    return _group_or_org_update(
+    return _querytool_group_or_org_update(
         context, data_dict
     )

--- a/ckanext/querytool/plugin.py
+++ b/ckanext/querytool/plugin.py
@@ -210,6 +210,14 @@ class QuerytoolPlugin(plugins.SingletonPlugin):
             'group_edit', '/group/edit/{id}',
             controller=group_controller, action='edit'
         )
+        map.connect(
+            'group_new', '/group/new',
+            controller=group_controller, action='new'
+        )
+        map.connect(
+            'group_delete', '/group/delete/{id}',
+            controller=group_controller, action='delete'
+        )
 
         # Query tool routes
         map.redirect('/querytool', '/querytool/groups',

--- a/ckanext/querytool/templates/group/index.html
+++ b/ckanext/querytool/templates/group/index.html
@@ -10,7 +10,7 @@
 
 {% block page_primary_action %}
   {% if h.check_access('group_create') %}
-    {% link_for _('Add Group'), controller='group', action='new', class_='btn btn-primary', icon='plus-square' %}
+    {% link_for _('Add Group'), controller='ckanext.querytool.controllers.group:QuerytoolGroupController', action='new', class_='btn btn-primary', icon='plus-square' %}
   {% endif %}
 
   {% set ctrl = 'ckanext.querytool.controllers.querytool:QueryToolController' %}

--- a/ckanext/querytool/templates/group/snippets/group_form.html
+++ b/ckanext/querytool/templates/group/snippets/group_form.html
@@ -69,7 +69,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('group_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Group?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='ckanext.querytool.controllers.group:QuerytoolGroupController', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Group?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Group') }}{% endblock %}</button>


### PR DESCRIPTION
Addresses https://gitlab.com/datopian/vital-strategies-ui/-/issues/253

To test, create a new user (this can be an organization Editor or Admin—_not_ a Sys Admin), then as that user, visit the home page and the "Design Reports" page (previously displayed internal server errors).

Also, this fix required changes to the parent/child group functionality, so those need to be tested as well (test the previous points both with and without parent groups enabled):
- Creating new parent and child groups
- Changing and removing the parent/child of an existing group
- The home page parent groups list the correct children when you visit their link
- Parent group children pages search works (the search that appears once you've clicked on a parent on the home page)
- Deleting a parent/child group (this should remove the relationship, so deleting a parent should place the child in "Other", and deleting a child should remove it from the parent list)