### PR TITLE
feat: inject Khmer font when language is km

### DIFF
--- a/ckanext/querytool/templates/base.html
+++ b/ckanext/querytool/templates/base.html
@@ -5,6 +5,17 @@
   <!-- Reference: https://flagicons.lipis.dev/ -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@6.6.6/css/flag-icons.min.css">
 
+  {% set current_lang = request.environ.CKAN_LANG %}
+
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Khmer">
+<style>div:has(.fi-kh) { font-family: Khmer !important }</style>
+  {% if current_lang == 'km' %}
+    <style>
+      *:not(i):not(.fa) {font-family: Khmer !important}
+    </style>
+  {% endif %}
+
+
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <script>

--- a/ckanext/querytool/templates/querytool/public/base_main.html
+++ b/ckanext/querytool/templates/querytool/public/base_main.html
@@ -131,7 +131,7 @@
       </div>
     </div>
 
-    <a class="query-tool query-btn" href="/querytool/public/reports">
+    <a class="query-tool query-btn" href="{{ h.url_for("querytool_public_reports") }}">
       <span class="btn btn-primary" role="button" style="display: block; max-width:200px; margin:0 auto; padding:10px 10px;">{{ _('See all tools') }}</span>
     </a>
     <br/><br/><br/><br/>


### PR DESCRIPTION
## Changes

- Khmer font is now injected and the "Khmer" option on the language selector shouldn't display squares anymore when the user doesn't have the font installed
- When Khmer is the current language, content shouldn't display squares
- Icons should still be working

![image](https://github.com/datopian/ckanext-querytool/assets/16550934/da5435a4-c09c-40a0-8d02-8a5b1833d6dd)
