### PR TITLE
Fix weird group pagination

### DIFF
--- a/ckanext/querytool/templates/group/snippets/group_list.html
+++ b/ckanext/querytool/templates/group/snippets/group_list.html
@@ -9,7 +9,7 @@ Example:
 
 #}
 {% block group_list %}
-<ul class="media-grid bg-white bg-no-image" data-module="media-grid">
+<ul class="media-grid bg-white bg-no-image">
 	{% block group_list_inner %}
   {% for group in groups %}
     {% snippet "group/snippets/group_item.html", group=group, position=loop.index, show_capacity=show_capacity %}


### PR DESCRIPTION
There is a script somewhere (it seems to be coming from ckan) that if an element has the property `data-module=media-grid` it will maek the height 14px and the position relative, removing that fixed the issue