### PR TITLE
Luis fixes

### DIFF
--- a/ckanext/querytool/assets/style.css
+++ b/ckanext/querytool/assets/style.css
@@ -1871,6 +1871,14 @@ ol.inline {
   margin-top: 1rem;
 }
 
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
 .item-wrapper .control-group .controls select,
 .item-wrapper .control-group .controls textarea,
 .item-wrapper .control-group .controls input,

--- a/ckanext/querytool/templates/group/edit.html
+++ b/ckanext/querytool/templates/group/edit.html
@@ -1,0 +1,13 @@
+{% extends "group/base_form_page.html" %}
+{% set group_name = group_dict.title if group_dict.title|length > 0 else group_dict.name %}
+
+{% block breadcrumb_content %}
+  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
+  {% block breadcrumb_content_inner %}
+    <li>{% link_for group_name, named_route=group_type+'.read', id=group.name, title=group_name %}</li>
+    <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
+  {% endblock %}
+{% endblock %}
+
+{% block page_heading_class %}hide-heading{% endblock %}
+{% block page_heading %}{{ h.humanize_entity_type('group', group_type, 'edit label') or _('Edit Group') }}{% endblock %}

--- a/ckanext/querytool/templates/group/edit_base.html
+++ b/ckanext/querytool/templates/group/edit_base.html
@@ -1,0 +1,19 @@
+{% extends "page.html" %}
+{% set dataset_type = h.default_package_type() %}
+
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+
+{% set group = group_dict %}
+
+{% block content_action %}
+  {% link_for _('View'), named_route=group_type+'.read', id=group_dict.name, class_='btn btn-default', icon='eye' %}
+{% endblock %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil') }}
+  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name, icon='users') }}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet "group/snippets/info.html", group=group_dict, show_nums=false %}
+{% endblock %}

--- a/ckanext/querytool/templates/group/read_base.html
+++ b/ckanext/querytool/templates/group/read_base.html
@@ -1,11 +1,12 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
+{% set group_name = group_dict.title if group_dict.title|length > 0 else group_dict.name %}
 
 {% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name, title=group_dict.display_name %}</li>
+<li class="active">{% link_for group_name|truncate(35), named_route='group.read', id=group_dict.name, title=group_name %}</li>
 {% endblock %}
 
 {% block content_action %}
@@ -16,7 +17,7 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon(group_type + '.read', h.humanize_entity_type('package', dataset_type, 'content tab') or _('Datasets'), id=group_dict.name, icon='sitemap') }}
-  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name, icon='users') }}
+  {{ h.build_nav_icon('activity.group_activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock') }}
   {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name, icon='info-circle') }}
   {{ h.build_nav_icon('querytool_group.reports', _('Reports'), id=group_dict.name, icon='info-circle') }}
 {% endblock %}

--- a/ckanext/querytool/templates/group/reports.html
+++ b/ckanext/querytool/templates/group/reports.html
@@ -4,7 +4,7 @@
   {% set ctrl = 'ckanext.querytool.controllers.querytool:QueryToolController' %}
 
   {% if h.check_access('querytool_update') %}
-    {% link_for _('New Report'), named_route='reports.new', class_='btn btn-primary', icon='plus-square' %}
+    {% link_for _('New Report'), named_route='reports.new', class_='btn btn-primary mb-8', icon='plus-square' %}
   {% endif %}
 
   {% block reports_list %}
@@ -52,7 +52,7 @@
                   <li><a class="btn btn-minimal" role="button" href="{{ edit_data_url}}" type="submit" name="edit"><span class="fa fa-pencil" aria-hidden="true"></span> {{ _('Edit filters and data') }}</a></li>
                 {% endif %}
               <li><a class="btn btn-minimal" role="button" href="{{ h.url_for('reports.edit_visualizations', querytool=report.name) }}" type="submit" name="edit"><span class="fa fa-pencil" aria-hidden="true"></span> {{ _('Edit visualizations') }}</a></li>
-              <li><a class="btn btn-minimal" role="button" href="#" type="submit" name="view"><span class="fa fa-eye" aria-hidden="true"></span> {{ _('View') }}</a></li>
+<li><a class="btn btn-minimal" role="button" href="{{ h.url_for('querytool.querytool_public_read', name=report.name) }}" type="submit" name="view"><span class="fa fa-eye" aria-hidden="true"></span> {{ _('View') }}</a></li>
               <li><a class="btn delete-querytool-btn" href="{{ delete_url }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Report?') }}">{% block delete_button_text %}<span class="fa fa-trash-o" aria-hidden="true"></span> {{ _('Delete') }}{% endblock %}</a></li>
               {% else %}
                   <li><a class="btn" href="{{ h.url_for('querytool_public_read', name=report.name) }}" type="submit" name="view"><span class="fa fa-eye" aria-hidden="true"></span> {{ _('View') }}</a></li>

--- a/ckanext/querytool/templates/group/reports.html
+++ b/ckanext/querytool/templates/group/reports.html
@@ -13,7 +13,7 @@
       {% if report.type == 'main' %}
 
         {% set edit_data_url = h.url_for('reports.edit', querytool=report.name) %}
-        {% set delete_url = h.url_for('reports.delete', querytool='report.name') %}
+        {% set delete_url = h.url_for('reports.delete', querytool=report.name) %}
         {% set member_type = h.get_user_permission_type(userobj, report.group) %}
 
         {% if h.get_groups_for_user(userobj, report.group) and (member_type == 'member' or member_type == 'admin' or userobj.sysadmin) %}
@@ -67,11 +67,11 @@
     {% endfor %}
 
     <legend>{{ _('Related') }}</legend>
-    {% for querytool in reports %}
-      {% if querytool.type == 'related' %}
+    {% for report in reports %}
+      {% if report.type == 'related' %}
 
         {% set edit_data_url = h.url_for('reports.edit', querytool=report.name) %}
-        {% set delete_url = h.url_for('reports.delete', querytool='report.name') %}
+        {% set delete_url = h.url_for('reports.delete', querytool=report.name) %}
         {% set member_type = h.get_user_permission_type(userobj, report.group) %}
 
         <div class="query-item">

--- a/ckanext/querytool/templates/group/snippets/group_list.html
+++ b/ckanext/querytool/templates/group/snippets/group_list.html
@@ -9,7 +9,7 @@ Example:
 
 #}
 {% block group_list %}
-<ul class="media-grid bg-white bg-no-image" data-module="media-grid">
+<ul class="media-grid bg-white bg-no-image">
 	{% block group_list_inner %}
   {% for group in groups %}
     {% snippet "group/snippets/group_item.html", group=group, position=loop.index, show_capacity=show_capacity %}

--- a/ckanext/querytool/templates/header.html
+++ b/ckanext/querytool/templates/header.html
@@ -92,7 +92,7 @@
                 {% set org_type = h.default_group_type('organization') %}	
                 {% set group_type = h.default_group_type('group') %}	
                 {{ h.build_nav_main(('home.index', _('Home') ),	
-                ('reports.reports_list', _('Reports')) ) }}
+                ('querytool.querytool_public_reports', _('Reports')) ) }}
               {% endblock %}	
             </ul>	
           {% endblock %}	

--- a/ckanext/querytool/views/reports.py
+++ b/ckanext/querytool/views/reports.py
@@ -193,8 +193,11 @@ def querytool_edit(data=None, errors=None, error_summary=None, querytool=None):
             error_summary = e.error_summary
             return querytool_edit("/" + querytool, _querytool, errors, error_summary)
         if "save_data" in list(data.keys()):
+            url = ckan_helpers.url_for(
+                "querytool_group.reports", id=group['name']
+            )
             # redirect to report list
-            return ckan_helpers.redirect_to("/report")
+            return ckan_helpers.redirect_to(url)
 
         else:
             # redirect to manage visualisations
@@ -770,7 +773,10 @@ def edit_visualizations(
             # return ckan_helpers.redirect_to(
             #    "/" + ckan_helpers.lang() + "/group" + "/reports/" + _querytool["group"]
             # )
-            return ckan_helpers.redirect_to("reports.reports_list")
+            url = ckan_helpers.url_for(
+                "querytool_group.reports", id=_querytool['group']
+            )
+            return ckan_helpers.redirect_to(url)
 
     if not data:
         data = _visualization_items


### PR DESCRIPTION
- Saving a report and editing now redirects to the report group page
- Fixed the header link for "Reports" it now redirects to the public page
- Fixed the view button in the reports list inside the group page to work
- Fixed the tabs in the groups page to now have "Datasets/Reports/Activity Stream/About" just like in the old portal